### PR TITLE
✨ Add the possibility to have dark and light logos

### DIFF
--- a/demo/doczrc.js
+++ b/demo/doczrc.js
@@ -35,7 +35,11 @@ export default {
       navigation: true,
     },
     logo: {
-      src: '/public/assets/logo.svg',
+      // src: '/public/assets/logo.svg' // use this line if you want one logo for both color modes
+      src: {
+        light: '/public/assets/logo.svg',
+        dark: '/public/assets/logo-dark.svg'
+      },
       width: 45,
     },
     menu: {

--- a/demo/public/assets/logo-dark.svg
+++ b/demo/public/assets/logo-dark.svg
@@ -3,8 +3,8 @@
 <svg version="1.1" id="NM" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#184353;}
-	.st1{fill:#FFFFFF;}
+	.st0{fill:#588393;}
+	.st1{fill:#000000;}
 </style>
 <path class="st0" d="M498.9,0H13.1C6,0,0.3,10,0.3,22.1v467.9C0.3,502,6.1,512,13.1,512H499c7,0,12.8-10,12.8-22.1V22.1
 	C511.7,10,506,0,498.9,0z"/>

--- a/theme/src/gatsby-theme-docz/components/Logo/index.js
+++ b/theme/src/gatsby-theme-docz/components/Logo/index.js
@@ -1,14 +1,17 @@
 /** @jsx jsx */
 import {Link, useConfig} from 'docz';
 import * as styles from 'gatsby-theme-docz/src/components/Logo/styles';
-import {Flex, jsx} from 'theme-ui';
+import {Flex, jsx, useColorMode} from 'theme-ui';
 import {getPublicUrl} from '../../helpers';
 import {Image} from './custom-styles';
 
 export const Logo = () => {
   const config = useConfig();
+  const [colorMode] = useColorMode();
   const {width = '100%', src} = config.themeConfig.logo || {};
   const len = (config.title || '').length;
+
+  const imagePath = typeof src === 'string' ? src : src[colorMode];
 
   return (
     <div sx={styles.logo} data-testid="logo">
@@ -16,16 +19,16 @@ export const Logo = () => {
         <Flex
           sx={{alignItems: 'center', flexDirection: 'row', lineHeight: 1.2}}
         >
-          {src ? (
+          {imagePath ? (
             <Image
               className="logo"
-              src={getPublicUrl(config.base, src)}
+              src={getPublicUrl(config.base, imagePath)}
               width={width}
               height="auto"
               alt={config.title}
             />
           ) : null}
-          <span className={len > 12 && src ? 'h-sm' : ''}>{config.title}</span>
+          <span className={len > 12 && imagePath ? 'h-sm' : ''}>{config.title}</span>
         </Flex>
       </Link>
     </div>


### PR DESCRIPTION
A feature I was missing on this awesome theme was the possibility to have a light-logo and a dark-logo that changes when the user switches between dark and light mode.

This PR includes such possibility, being able to change the config as follows to switch between logos:

```
    logo: {
      src: {
        light: '/public/assets/logo.svg',
        dark: '/public/assets/logo-dark.svg'
      },
      width: 45,
    },
```

And also keep the old way of having one url for both color modes:

```
    logo: {
      src: '/public/assets/logo.svg',
      width: 45,
    },
```