### PR TITLE
Props Table - Better responsive design and default value overflow style

### DIFF
--- a/theme/src/gatsby-theme-docz/components/Logo/index.js
+++ b/theme/src/gatsby-theme-docz/components/Logo/index.js
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import {Link, useConfig} from 'docz';
 import * as styles from 'gatsby-theme-docz/src/components/Logo/styles';
-import {get} from 'lodash/fp';
 import {Flex, jsx, useColorMode} from 'theme-ui';
 import {getPublicUrl} from '../../helpers';
 import {Image} from './custom-styles';

--- a/theme/src/gatsby-theme-docz/components/Logo/index.js
+++ b/theme/src/gatsby-theme-docz/components/Logo/index.js
@@ -11,7 +11,7 @@ export const Logo = () => {
   const {width = '100%', src} = config.themeConfig.logo || {};
   const len = (config.title || '').length;
 
-  const imagePath = typeof src === 'string' ? src : src[colorMode];
+  const imagePath = typeof src === 'object' ? src[colorMode] : src;
 
   return (
     <div sx={styles.logo} data-testid="logo">

--- a/theme/src/gatsby-theme-docz/components/Props/custom-styles.js
+++ b/theme/src/gatsby-theme-docz/components/Props/custom-styles.js
@@ -1,6 +1,12 @@
 import styled from '@emotion/styled';
 
-import { defaultValue as originalDefaultValue, container as originalContainer } from "gatsby-theme-docz/src/components/Props/styles";
+import {
+  defaultValue as originalDefaultValue,
+  container as originalContainer,
+  propName as originalPropName,
+  propType as originalPropType,
+  right as originalRight,
+} from 'gatsby-theme-docz/src/components/Props/styles';
 
 export const Container = styled.div`
   width: 100%;
@@ -16,13 +22,13 @@ export const Container = styled.div`
 
     th,
     td {
-      border-bottom: solid 1px ${({theme}) => theme.colors.border};
+      border-bottom: solid 1px ${({ theme }) => theme.colors.border};
       padding: 12px 8px;
       min-height: 68px;
     }
 
     th {
-      color: ${({theme}) => theme.colors.gray};
+      color: ${({ theme }) => theme.colors.gray};
     }
     td {
       p {
@@ -32,12 +38,17 @@ export const Container = styled.div`
   }
 `;
 
-export const container = { ...originalContainer,
-  overflow: 'none'
-}
+export const container = { ...originalContainer, overflow: 'none' };
 
-export const defaultValue = { ...originalDefaultValue,
-  maxWidth: '65%',
+export const propName = { ...originalPropName, minWidth: '150px' };
+
+export const propType = { ...originalPropType, minWidth: '150px' };
+
+export const right = { ...originalRight, minWidth: '150px' };
+
+export const defaultValue = {
+  ...originalDefaultValue,
+  maxWidth: '50%',
   overflow: 'hidden',
   '&[data-hovertext]': {
     cursor: 'help',
@@ -56,5 +67,6 @@ export const defaultValue = { ...originalDefaultValue,
     color: '#FFF',
     borderRadius: 10,
     whiteSpace: 'pre-wrap',
-  }
-}
+    zIndex: 10
+  },
+};

--- a/theme/src/gatsby-theme-docz/components/Props/custom-styles.js
+++ b/theme/src/gatsby-theme-docz/components/Props/custom-styles.js
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import { defaultValue as originalDefaultValue } from "gatsby-theme-docz/src/components/Props/styles";
+
 export const Container = styled.div`
   width: 100%;
   overflow: auto;
@@ -29,3 +31,21 @@ export const Container = styled.div`
     }
   }
 `;
+
+export const defaultValue = { ...originalDefaultValue,
+  textOverflow: 'ellipsis',
+  maxWidth: '65%',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  '&[data-hovertext]': {
+    position: 'relative',
+    cursor: 'help'
+  },
+  '&[data-hovertext]:hover::before': {
+    position: 'absolute',
+    bottom: -46,
+    padding: '10px 20px',
+    background: '#333',
+    color: '#FFF',
+    borderRadius: 10
+  }}

--- a/theme/src/gatsby-theme-docz/components/Props/custom-styles.js
+++ b/theme/src/gatsby-theme-docz/components/Props/custom-styles.js
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import { defaultValue as originalDefaultValue } from "gatsby-theme-docz/src/components/Props/styles";
+import { defaultValue as originalDefaultValue, container as originalContainer } from "gatsby-theme-docz/src/components/Props/styles";
 
 export const Container = styled.div`
   width: 100%;
@@ -32,20 +32,29 @@ export const Container = styled.div`
   }
 `;
 
+export const container = { ...originalContainer,
+  overflow: 'none'
+}
+
 export const defaultValue = { ...originalDefaultValue,
-  textOverflow: 'ellipsis',
   maxWidth: '65%',
   overflow: 'hidden',
-  whiteSpace: 'nowrap',
   '&[data-hovertext]': {
-    position: 'relative',
-    cursor: 'help'
+    cursor: 'help',
+    whiteSpace: 'nowrap',
+  },
+  '&[data-hovertext] > em': {
+    display: 'block',
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
   },
   '&[data-hovertext]:hover::before': {
+    content: 'attr(data-hovertext)',
     position: 'absolute',
-    bottom: -46,
     padding: '10px 20px',
     background: '#333',
     color: '#FFF',
-    borderRadius: 10
-  }}
+    borderRadius: 10,
+    whiteSpace: 'pre-wrap',
+  }
+}

--- a/theme/src/gatsby-theme-docz/components/Props/custom-styles.js
+++ b/theme/src/gatsby-theme-docz/components/Props/custom-styles.js
@@ -50,6 +50,7 @@ export const defaultValue = {
   ...originalDefaultValue,
   maxWidth: '50%',
   overflow: 'hidden',
+  color: (theme) => `${theme.colors.props.descriptionText}`,
   '&[data-hovertext]': {
     cursor: 'help',
     whiteSpace: 'nowrap',
@@ -63,10 +64,12 @@ export const defaultValue = {
     content: 'attr(data-hovertext)',
     position: 'absolute',
     padding: '10px 20px',
-    background: '#333',
-    color: '#FFF',
+    background: (theme) => `${theme.colors.props.descriptionBg}`,
+    color: (theme) => `${theme.colors.props.descriptionText}`,
+    border: (theme) => `1px solid ${theme.colors.props.descriptionText}`,
     borderRadius: 10,
     whiteSpace: 'pre-wrap',
+    fontStyle: 'italic',
     zIndex: 10
   },
 };

--- a/theme/src/gatsby-theme-docz/components/Props/index.js
+++ b/theme/src/gatsby-theme-docz/components/Props/index.js
@@ -27,6 +27,7 @@ export const Prop = ({propName, prop, getPropType, isToggle}) => {
   if (!prop.type && !prop.flowType) return null;
 
   const toggle = () => setShowing((s) => !s);
+  const defaultValue = getDefaultValue(prop)
   return (
     <div sx={styles.line} data-testid="prop">
       <div sx={styles.content}>
@@ -37,8 +38,8 @@ export const Prop = ({propName, prop, getPropType, isToggle}) => {
           {getPropType(prop)}
         </div>
         {prop.defaultValue && (
-          <div sx={styles.defaultValue} data-testid="prop-default-value">
-            <em>{getDefaultValue(prop)}</em>
+          <div sx={styles.defaultValue} data-testid="prop-default-value" data-hovertext={defaultValue}>
+            <em>{defaultValue}</em>
           </div>
         )}
         <div sx={styles.right}>

--- a/theme/src/gatsby-theme-docz/components/Props/index.js
+++ b/theme/src/gatsby-theme-docz/components/Props/index.js
@@ -1,13 +1,20 @@
 /* eslint-disable react/prop-types */
 /** @jsx jsx */
-import {ChevronDown, ChevronUp} from 'gatsby-theme-docz/src/components/Icons';
+import { ChevronDown, ChevronUp } from 'gatsby-theme-docz/src/components/Icons';
 import * as styles from 'gatsby-theme-docz/src/components/Props/styles';
-import {useState} from 'react';
-import {jsx} from 'theme-ui';
-import {InlineCode} from '../../custom-components/InlineCode';
-import {Container, defaultValue as propsDefaultValue, container as propsContainer} from './custom-styles';
+import { useState } from 'react';
+import { jsx } from 'theme-ui';
+import { InlineCode } from '../../custom-components/InlineCode';
+import {
+  Container,
+  defaultValue as propsDefaultValue,
+  container as propsContainer,
+  propName as propsPropName,
+  propType as propsPropType,
+  right as propsRight,
+} from './custom-styles';
 
-export const getDefaultValue = ({defaultValue, type, flowType}) => {
+export const getDefaultValue = ({ defaultValue, type, flowType }) => {
   const propType = flowType ? flowType : type;
   if (!defaultValue || !defaultValue.value) return null;
   if (defaultValue.value === "''") {
@@ -22,38 +29,38 @@ export const getDefaultValue = ({defaultValue, type, flowType}) => {
   return defaultValue.value;
 };
 
-export const Prop = ({propName, prop, getPropType, isToggle}) => {
+export const Prop = ({ propName, prop, getPropType, isToggle }) => {
   const [showing, setShowing] = useState(isToggle || false);
   if (!prop.type && !prop.flowType) return null;
 
   const toggle = () => setShowing((s) => !s);
-  const defaultValue = getDefaultValue(prop)
+  const defaultValue = getDefaultValue(prop);
   return (
     <div sx={styles.line} data-testid="prop">
       <div sx={styles.content}>
-        <div sx={styles.propName} data-testid="prop-name">
+        <div sx={propsPropName} data-testid="prop-name">
           {propName}
         </div>
-        <div sx={styles.propType} data-testid="prop-type">
+        <div sx={propsPropType} data-testid="prop-type">
           {getPropType(prop)}
         </div>
         {prop.defaultValue && (
-          <div sx={propsDefaultValue} data-testid="prop-default-value" data-hovertext={defaultValue}>
+          <div
+            sx={propsDefaultValue}
+            data-testid="prop-default-value"
+            data-hovertext={defaultValue.length > 150 ? defaultValue : undefined}
+          >
             <em>{defaultValue}</em>
           </div>
         )}
-        <div sx={styles.right}>
+        <div sx={propsRight}>
           {prop.required && (
             <div sx={styles.propRequired} data-testid="prop-required">
               <strong>required</strong>
             </div>
           )}
           {prop.description && (
-            <button
-              sx={styles.openDescBtn}
-              onClick={toggle}
-              data-testid="prop-toggle-description"
-            >
+            <button sx={styles.openDescBtn} onClick={toggle} data-testid="prop-toggle-description">
               {showing ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
             </button>
           )}
@@ -68,7 +75,7 @@ export const Prop = ({propName, prop, getPropType, isToggle}) => {
   );
 };
 
-export const Props = ({props, table, getPropType, isToggle}) => {
+export const Props = ({ props, table, getPropType, isToggle }) => {
   const entries = Object.entries(props);
 
   if (table) {
@@ -105,13 +112,7 @@ export const Props = ({props, table, getPropType, isToggle}) => {
   return (
     <div sx={propsContainer} data-testid="props">
       {entries.map(([key, prop]) => (
-        <Prop
-          key={key}
-          propName={key}
-          prop={prop}
-          getPropType={getPropType}
-          isToggle={isToggle}
-        />
+        <Prop key={key} propName={key} prop={prop} getPropType={getPropType} isToggle={isToggle} />
       ))}
     </div>
   );

--- a/theme/src/gatsby-theme-docz/components/Props/index.js
+++ b/theme/src/gatsby-theme-docz/components/Props/index.js
@@ -5,7 +5,7 @@ import * as styles from 'gatsby-theme-docz/src/components/Props/styles';
 import {useState} from 'react';
 import {jsx} from 'theme-ui';
 import {InlineCode} from '../../custom-components/InlineCode';
-import {Container} from './custom-styles';
+import {Container, defaultValue as propsDefaultValue, container as propsContainer} from './custom-styles';
 
 export const getDefaultValue = ({defaultValue, type, flowType}) => {
   const propType = flowType ? flowType : type;
@@ -38,7 +38,7 @@ export const Prop = ({propName, prop, getPropType, isToggle}) => {
           {getPropType(prop)}
         </div>
         {prop.defaultValue && (
-          <div sx={styles.defaultValue} data-testid="prop-default-value" data-hovertext={defaultValue}>
+          <div sx={propsDefaultValue} data-testid="prop-default-value" data-hovertext={defaultValue}>
             <em>{defaultValue}</em>
           </div>
         )}
@@ -76,26 +76,26 @@ export const Props = ({props, table, getPropType, isToggle}) => {
       <Container>
         <table>
           <thead>
-            <tr>
-              <th width="17%">Prop name</th>
-              <th width="25%">Type</th>
-              <th width="9%">Default</th>
-              <th width="9%">Required</th>
-              <th width="40%">Description</th>
-            </tr>
+          <tr>
+            <th width="17%">Prop name</th>
+            <th width="25%">Type</th>
+            <th width="9%">Default</th>
+            <th width="9%">Required</th>
+            <th width="40%">Description</th>
+          </tr>
           </thead>
           <tbody>
-            {entries.map(([key, prop]) => (
-              <tr key={key}>
-                <td>{key}</td>
-                <td>
-                  <InlineCode>{getPropType(prop)}</InlineCode>
-                </td>
-                <td>{getDefaultValue(prop) || '—'}</td>
-                <td>{prop.required ? 'true' : 'false'}</td>
-                <td>{prop.description}</td>
-              </tr>
-            ))}
+          {entries.map(([key, prop]) => (
+            <tr key={key}>
+              <td>{key}</td>
+              <td>
+                <InlineCode>{getPropType(prop)}</InlineCode>
+              </td>
+              <td>{getDefaultValue(prop) || '—'}</td>
+              <td>{prop.required ? 'true' : 'false'}</td>
+              <td>{prop.description}</td>
+            </tr>
+          ))}
           </tbody>
         </table>
       </Container>
@@ -103,7 +103,7 @@ export const Props = ({props, table, getPropType, isToggle}) => {
   }
 
   return (
-    <div sx={styles.container} data-testid="props">
+    <div sx={propsContainer} data-testid="props">
       {entries.map(([key, prop]) => (
         <Prop
           key={key}


### PR DESCRIPTION
This PR changes how the Props table behaves on responsive mode by adding a minimum width to its elements.

It also enhances the visualization of default values on the table, making a text ellipsis for long elements and enabling a tooltip with the whole text on description hover:
![firefox_E3RqmvGbOA](https://user-images.githubusercontent.com/16889094/90758842-eb362500-e2df-11ea-9717-5a89fbc7ffb3.png)
![firefox_TP3drrEFfN](https://user-images.githubusercontent.com/16889094/90758846-ee311580-e2df-11ea-8f84-cd917f991367.png)

It also includes a commit to fix a bug within the logo.src property, as if it's undefined it tries to access the light/dark properties while they don't exist.